### PR TITLE
install DB initially in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,11 +203,13 @@ RUN apt-get update && \
     curl nodejs sudo wget procps nano && \
     rm -rf /var/lib/apt/lists/*
 
+COPY ex_app_scripts/common_pgsql.sh /ex_app_scripts/common_pgsql.sh
+COPY ex_app_scripts/install_pgsql.sh /ex_app_scripts/install_pgsql.sh
 COPY ex_app_scripts/init_pgsql.sh /ex_app_scripts/init_pgsql.sh
 COPY ex_app_scripts/set_workers_num.sh /ex_app_scripts/set_workers_num.sh
 COPY ex_app_scripts/entrypoint.sh /ex_app_scripts/entrypoint.sh
 
-RUN chmod +x /ex_app_scripts/*.sh
+RUN chmod +x /ex_app_scripts/*.sh && /ex_app_scripts/install_pgsql.sh && rm /ex_app_scripts/install_pgsql.sh
 
 COPY requirements.txt /ex_app_requirements.txt
 

--- a/ex_app_scripts/common_pgsql.sh
+++ b/ex_app_scripts/common_pgsql.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+# Common environment variables
+PG_VERSION=15
+PG_BIN="/usr/lib/postgresql/${PG_VERSION}/bin"
+PG_SQL="/usr/lib/postgresql/${PG_VERSION}/bin/psql"
+BASE_DIR="${APP_PERSISTENT_STORAGE:-/nc_app_${APP_ID:-flow}_data}"
+DATA_DIR="${BASE_DIR}/pgsql"
+
+# Function to ensure PostgreSQL is installed
+ensure_postgres_installed() {
+    # Check if PostgreSQL is installed by checking for the existence of binary files
+    if [ -d "$PG_BIN" ]; then
+        echo "PostgreSQL binaries found."
+    else
+        echo "PostgreSQL binaries not found."
+        echo "Adding the PostgreSQL APT repository..."
+        apt-get update && apt-get install -y gnupg
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+        echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+        echo "Installing PostgreSQL..."
+        apt-get update && apt-get install -y postgresql-$PG_VERSION
+    fi
+}
+
+# Function to initialize the database (if needed) and start PostgreSQL
+init_and_start_postgres() {
+    # Ensure the directory exists and has the correct permissions
+    mkdir -p "$DATA_DIR"
+    chown -R postgres:postgres "$DATA_DIR"
+
+    if [ ! -d "$DATA_DIR/base" ]; then
+        echo "Initializing the PostgreSQL database..."
+        sudo -u postgres ${PG_BIN}/initdb -D "$DATA_DIR"
+    fi
+
+    echo "Starting PostgreSQL..."
+    sudo -u postgres ${PG_BIN}/pg_ctl -D "$DATA_DIR" -l "${DATA_DIR}/logfile" start
+
+    echo "Waiting for PostgreSQL to start..."
+    until sudo -u postgres ${PG_SQL} -c "SELECT 1" > /dev/null 2>&1; do
+        sleep 1
+        echo -n "."
+    done
+    echo "PostgreSQL is up and running."
+}

--- a/ex_app_scripts/install_pgsql.sh
+++ b/ex_app_scripts/install_pgsql.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+source /ex_app_scripts/common_pgsql.sh
+
+ensure_postgres_installed
+init_and_start_postgres


### PR DESCRIPTION
Probably, will resolve such issues: https://github.com/nextcloud/flow/issues/16

ContextChat has already switched to something similar, installing DB packages in the OS not during application initialization, but having them in the docker image right away.

Reduces the first start time significantly after installation, as well as the likelihood of errors that are very difficult to catch during this.