### PR TITLE
fix: SPDX license script - preventing release in AppStore

### DIFF
--- a/build-js/npm-post-build.sh
+++ b/build-js/npm-post-build.sh
@@ -5,19 +5,30 @@
 
 set -e
 
-# Add licenses for source maps
-if [ -d "js" ]; then
-	for f in js/*.js; do
-		# If license file and source map exists copy license for the source map
-		if [ -f "$f.license" ] && [ -f "$f.map" ]; then
-			# Remove existing link
-			[ -e "$f.map.license" ] || [ -L "$f.map.license" ] && rm "$f.map.license"
-			# Create a new link
-			ln -s "$(basename "$f.license")" "$f.map.license"
-		fi
-	done
-	echo "Copying licenses for sourcemaps done"
-else
+# Directories to process (space-separated)
+directories="js ex_app/js"
+
+found_any_directory=false
+
+for dir in $directories; do
+	if [ -d "$dir" ]; then
+		found_any_directory=true
+		# Process all .js files in this directory
+		for f in "$dir"/*.js; do
+			# If license file and source map exists copy license for the source map
+			if [ -f "$f.license" ] && [ -f "$f.map" ]; then
+				# Remove existing link
+				[ -e "$f.map.license" ] || [ -L "$f.map.license" ] && rm "$f.map.license"
+				# Create a new link
+				ln -s "$(basename "$f.license")" "$f.map.license"
+			fi
+		done
+	fi
+done
+
+if [ "$found_any_directory" = false ]; then
 	echo "This script needs to be executed from the root of the repository"
 	exit 1
 fi
+
+echo "Copying licenses for sourcemaps done"


### PR DESCRIPTION
In new ExApps we put `js` files in `ex_app/js` path - to avoid conflicts with services that may be embedded in the future.

The script that generates SPDX licenses does not take this into account, and if it does not find the `js` folder, it thinks that it was run in the wrong directory, which prevents us from publishing the new version of Flow to the AppStore. (link: https://github.com/nextcloud/flow/actions/runs/12762721174/job/35571686996)

I slightly modified the script to look for files in the `ex_app/js` folder, as a fallback.