### PR TITLE
feat(appstore): add app to "flow" category

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,6 +31,7 @@ This app provides an easy way to install the Windmill based Business Process Aut
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
 	<namespace>PyAppV2_flow</namespace>
 	<category>tools</category>
+	<category>flow</category>
 	<website>https://github.com/nextcloud/flow</website>
 	<bugs>https://github.com/nextcloud/flow/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/flow</repository>


### PR DESCRIPTION
Fixes #6

Since users can't find from where to install this application, and there are already too many apps in the "tools" category, we will add the application to the already existing "Flow" category.
