### PR TITLE
feat(database): use database via unix-socket

### DIFF
--- a/ex_app_scripts/common_pgsql.sh
+++ b/ex_app_scripts/common_pgsql.sh
@@ -34,6 +34,11 @@ init_and_start_postgres() {
     if [ ! -d "$DATA_DIR/base" ]; then
         echo "Initializing the PostgreSQL database..."
         sudo -u postgres ${PG_BIN}/initdb -D "$DATA_DIR"
+        PG_CONF="${DATA_DIR}/postgresql.conf"
+        if ! grep -q "^listen_addresses\s*=\s*''" "$PG_CONF"; then
+            echo "Updating PostgreSQL configuration to disable TCP/IP connections..."
+            echo "listen_addresses = ''" >> "$PG_CONF"
+        fi
     fi
 
     echo "Starting PostgreSQL..."

--- a/ex_app_scripts/init_pgsql.sh
+++ b/ex_app_scripts/init_pgsql.sh
@@ -38,11 +38,11 @@ sudo -u postgres $PG_SQL -c "CREATE DATABASE $DB_NAME OWNER $DB_USER;"
 
 if [ -z "${DATABASE_URL}" ]; then
     # Set DATABASE_URL environment variable
-    DATABASE_URL="postgres://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME"
+    DATABASE_URL="postgresql://$DB_USER:$DB_PASS@%2Fvar%2Frun%2Fpostgresql/$DB_NAME?sslmode=disable"
 
     # Check if DATABASE_URL is already in /etc/environment, if not, add it
     if ! grep -q "^export DATABASE_URL=" /etc/environment; then
-        echo "export DATABASE_URL=\"postgres://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME\"" >> /etc/environment
+        echo "export DATABASE_URL=\"postgresql://$DB_USER:$DB_PASS@%2Fvar%2Frun%2Fpostgresql/$DB_NAME?sslmode=disable\"" >> /etc/environment
     fi
 
     echo "DATABASE_URL was not set. It is now set to: $DATABASE_URL"


### PR DESCRIPTION
It will help in some cases when the application is installed remotely, with `network=host`, and another PgSQL is already installed in the host and this leads to a conflict at the when ExApp is deployed but can not start PgSQL.

note: affects only news installations, with clean `persistent storage volumes`