### PR TITLE
feat(Env-NUM_WORKERS): ability to control Windmill workers count

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For users familiar with Windmill, Flow offers additional advanced features that 
 
 > **Note:**
 >
-> This is only supported starting from Nextcloud version `32.0.0`
+> This is only supported starting from Nextcloud version `31.0.4`
 
 **Q: How can I control the number of Windmill workers?**
 **A:** You can set the `NUM_WORKERS` environment variable. The default value is `number_of_cpu_cores * 2`.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -69,5 +69,17 @@ This app provides an easy way to install the Windmill based Business Process Aut
 				<headers_to_exclude>[]</headers_to_exclude>
 			</route>
 		</routes>
+		<environment-variables>
+			<variable>
+				<name>NUM_WORKERS</name>
+				<display-name>Number of workers</display-name>
+				<description>Override the default count of Windmill workers</description>
+			</variable>
+			<variable>
+				<name>EXTERNAL_DATABASE</name>
+				<display-name>External database</display-name>
+				<description>External database URL in format: postgres://db_user:db_pass@db_address:5432/db_name</description>
+			</variable>
+		</environment-variables>
 	</external-app>
 </info>


### PR DESCRIPTION
Resolves #25

We have added such ability in AppAPI for Nextcloud 32, and this feature was backported to Nextcloud 31 at the start of this year.