### PR TITLE
feat: ability to set loglevel of Windmill

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -80,6 +80,12 @@ This app provides an easy way to install the Windmill based Business Process Aut
 				<display-name>External database</display-name>
 				<description>External database URL in format: postgres://db_user:db_pass@db_address:5432/db_name</description>
 			</variable>
+			<variable>
+				<name>RUST_LOG</name>
+				<display-name>Windmill log level</display-name>
+				<description>Possible values: debug, info, warn, error</description>
+				<default>warn</default>
+			</variable>
 		</environment-variables>
 	</external-app>
 </info>


### PR DESCRIPTION
Resolves: #51

1. Added ability to set custom log level during installation.
2. Changed default loglevel from `info` to `warn` to remove those spamming messages from Windmill workers(linked issue).

This will work only for Nextcloud 31. _(Nextcloud 30 does not support setting enviroment variables for ExApps)_