### PR TITLE
fix: support a bit longer NC usernames by removing "wapp_" prefix

### DIFF
--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -198,6 +198,10 @@ def get_windmill_username_from_request(request: Request) -> str:
         username = ""
     if not username:
         return ""
+    if len("wapp_") + len(username) + len("@windmill.dev") > 50:
+        # Length of the "email" field in Windmill is limited to 50 chars; do not append "wapp_" prefix in this case.
+        # When we can do the breaking change, we can remove the "wapp_" prefix completely + use the shorter suffix.
+        return username
     return "wapp_" + username
 
 


### PR DESCRIPTION
Relates to this issue: #17

When unticking in the `user_oidc` app the "Use unique user ID" checkbox, latest Flow version(that we expecting to release today) - works for me.

When the `Use unique user ID` is enabled - it still will fails, as Windmill does not support emails longer then **50 chars**, and username in that case more 64 characters(64 symbols is only size of hash).


