### PR TITLE
fix: enable deno_core feature for JavaScript expression evaluation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build-push:
 	docker login ghcr.io
 	docker buildx build --push \
 		--build-arg VITE_BASE_URL=/index.php/apps/app_api/proxy/flow \
-		--build-arg features=python \
+		--build-arg features=deno_core,python \
 		--platform linux/arm64/v8,linux/amd64 \
 		--tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION) \
 		--file windmill_src/Dockerfile \
@@ -66,7 +66,7 @@ build-push:
 build-amd64:
 	docker buildx build --load \
 		--build-arg VITE_BASE_URL=/index.php/apps/app_api/proxy/flow \
-		--build-arg features=python \
+		--build-arg features=deno_core,python \
 		--platform linux/amd64 \
 		--tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION) \
 		--file windmill_src/Dockerfile \


### PR DESCRIPTION
## Summary

- Enable the `deno_core` Cargo feature when building Windmill to fix JavaScript expression evaluation in workflows

## Problem

Since version 1.3.0, users get the error:
```
ExecutionErr: Error during isolated evaluation of expression: Deno core is not enabled
```

This happens because the `deno_core` Cargo feature was not enabled when building Windmill. This feature is required for Windmill to evaluate JavaScript/TypeScript expressions in workflows (e.g., `flow_input.event.values[0].value[0].id`).

## Solution

Add `deno_core` to the features build argument in the Makefile:
- `--build-arg features=python` → `--build-arg features=deno_core,python`

The `deno_core` feature enables the embedded JavaScript runtime based on deno_core and V8. This is different from the external Deno binary (`/usr/bin/deno`) which is already included in the image.

## Test plan

- [ ] Build the Docker image with `make init && make build-amd64`
- [ ] Verify that JavaScript expressions in workflows evaluate correctly without the "Deno core is not enabled" error

Fixes #129